### PR TITLE
Small fixes/enhancement to ALS readers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ coverage.xml
 *.sublime-workspace
 docs/trunk/*
 .spyder*
+.idea
 
 # Francesco's #
 ################

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -86,8 +86,7 @@ import dxchange.reader as dxreader
 logger = logging.getLogger(__name__)
 
 
-def read_als_832(fname, ind_tomo=None, normalized=False, proj=None,
-                 sino=None):
+def read_als_832(fname, ind_tomo=None, normalized=False, sino=None):
     """
     Read ALS 8.3.2 standard data format.
 
@@ -130,8 +129,6 @@ def read_als_832(fname, ind_tomo=None, normalized=False, proj=None,
     fname = os.path.abspath(fname)
 
     if not normalized:
-        fname = fname.split(
-            'output')[0] + fname.split('/')[len(fname.split('/')) - 1]
         tomo_name = fname + '_0000_0000.tif'
         flat_name = fname + 'bak_0000.tif'
         dark_name = fname + 'drk_0000.tif'
@@ -168,7 +165,7 @@ def read_als_832(fname, ind_tomo=None, normalized=False, proj=None,
 
     # Read image data from tiff stack.
     tomo = dxreader.read_tiff_stack(tomo_name, ind=ind_tomo, digit=4,
-                                    slc=(proj, sino))
+                                    slc=(sino, None))
 
     if not normalized:
 
@@ -201,7 +198,7 @@ def read_als_832(fname, ind_tomo=None, normalized=False, proj=None,
                     dy, dz = _arr.shape
                     flat = np.zeros((dx, dy, dz))
                 flat[m] = _arr
-            flat = dxreader._slice_array(flat, None)
+            flat = dxreader._slice_array(flat, (None, sino))
         else:
             flat = dxreader.read_tiff_stack(flat_name, ind=ind_flat, digit=4,
                                             slc=(sino, None))
@@ -213,8 +210,7 @@ def read_als_832(fname, ind_tomo=None, normalized=False, proj=None,
         # its scan, so xxxx is in incrementals of one, and yyyy is either
         # 0000 or the last projection.
 
-        list_dark = dxreader._list_file_stack(dark_name, ind_dark, digit=4,
-                                              slc=(sino, None))
+        list_dark = dxreader._list_file_stack(dark_name, ind_dark, digit=4)
         for x in ind_dark:
             body = os.path.splitext(list_dark[x])[0] + '_'
             ext = os.path.splitext(list_dark[x])[1]
@@ -228,7 +224,7 @@ def read_als_832(fname, ind_tomo=None, normalized=False, proj=None,
                 dy, dz = _arr.shape
                 dark = np.zeros((dx, dy, dz))
             dark[m] = _arr
-        dark = dxreader._slice_array(dark, None)
+        dark = dxreader._slice_array(dark, (None, sino))
     else:
         flat = np.ones(1)
         dark = np.zeros(1)

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -226,7 +226,7 @@ def read_als_832(fname, ind_tomo=None, normalized=False, sino=None):
 
 
 def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
-                   proj=None, sino=None, mult_flats=False):
+                   proj=None, sino=None):
     """
     Read ALS 8.3.2 hdf5 file with stacked datasets.
 
@@ -250,9 +250,6 @@ def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
 
     sino : {sequence, int}, optional
         Specify sinograms to read. (start, end, step)
-
-    mult_flats: bool, optional
-        Will return a list of locations where flat fields where taken in dataset.
 
     Returns
     -------
@@ -317,12 +314,7 @@ def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
         dark = dxreader.read_hdf5_stack(dgroup, dark_name, ind_dark, slc=(None, sino),
                                         out_ind=group_dark)
 
-        group_flat = dxreader._map_loc(ind_tomo, group_flat)
-
-    if mult_flats:
-        return tomo, flat, dark, group_flat
-    else:
-        return tomo, flat, dark
+    return tomo, flat, dark
 
 
 def read_anka_topotomo(

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -86,7 +86,8 @@ import dxchange.reader as dxreader
 logger = logging.getLogger(__name__)
 
 
-def read_als_832(fname, ind_tomo=None, normalized=False):
+def read_als_832(fname, ind_tomo=None, normalized=False, proj=None,
+                 sino=None):
     """
     Read ALS 8.3.2 standard data format.
 
@@ -103,6 +104,15 @@ def read_als_832(fname, ind_tomo=None, normalized=False):
         only be used for cases where tomo is already normalized.
         8.3.2 has a plugin that normalization is preferred to be
         done with prior to tomopy reconstruction.
+
+        proj : {sequence, int}, optional
+        Specify projections to read. (start, end, step)
+
+    proj : {sequence, int}, optional
+        Specify projections to read. (start, end, step)
+
+    sino : {sequence, int}, optional
+        Specify sinograms to read. (start, end, step)
 
     Returns
     -------
@@ -157,7 +167,8 @@ def read_als_832(fname, ind_tomo=None, normalized=False):
         ind_dark = list(range(0, ndark))
 
     # Read image data from tiff stack.
-    tomo = dxreader.read_tiff_stack(tomo_name, ind=ind_tomo, digit=4)
+    tomo = dxreader.read_tiff_stack(tomo_name, ind=ind_tomo, digit=4,
+                                    slc=(proj, sino))
 
     if not normalized:
 
@@ -192,7 +203,8 @@ def read_als_832(fname, ind_tomo=None, normalized=False):
                 flat[m] = _arr
             flat = dxreader._slice_array(flat, None)
         else:
-            flat = dxreader.read_tiff_stack(flat_name, ind=ind_flat, digit=4)
+            flat = dxreader.read_tiff_stack(flat_name, ind=ind_flat, digit=4,
+                                            slc=(sino, None))
 
         # Adheres to 8.3.2 flat/dark naming conventions:
         # ----Darks----
@@ -201,7 +213,8 @@ def read_als_832(fname, ind_tomo=None, normalized=False):
         # its scan, so xxxx is in incrementals of one, and yyyy is either
         # 0000 or the last projection.
 
-        list_dark = dxreader._list_file_stack(dark_name, ind_dark, digit=4)
+        list_dark = dxreader._list_file_stack(dark_name, ind_dark, digit=4,
+                                              slc=(sino, None))
         for x in ind_dark:
             body = os.path.splitext(list_dark[x])[0] + '_'
             ext = os.path.splitext(list_dark[x])[1]
@@ -325,7 +338,7 @@ def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
 def read_anka_topotomo(
         fname, ind_tomo, ind_flat, ind_dark, proj=None, sino=None):
     """
-    Read ANKA TOMO-TOMO standard data format.
+    Read ANKA TOPO-TOMO standard data format.
 
     Parameters
     ----------

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -279,55 +279,55 @@ def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
         Indices of flat field data within tomography projection list
     """
 
-    dgroup = dxreader.find_dataset_group(fname)
-    dname = dgroup.name.split('/')[-1]
+    with dxreader.find_dataset_group(fname) as dgroup:
+        dname = dgroup.name.split('/')[-1]
 
-    tomo_name = dname + '_0000_0000.tif'
-    flat_name = dname + 'bak_0000.tif'
-    dark_name = dname + 'drk_0000.tif'
+        tomo_name = dname + '_0000_0000.tif'
+        flat_name = dname + 'bak_0000.tif'
+        dark_name = dname + 'drk_0000.tif'
 
-    # Read metadata from dataset group attributes
-    keys = list(dgroup.attrs.keys())
-    if 'nangles' in keys:
-        nproj = int(dgroup.attrs['nangles'])
-    if 'i0cycle' in keys:
-        inter_bright = int(dgroup.attrs['i0cycle'])
-    if 'num_bright_field' in keys:
-        nflat = int(dgroup.attrs['num_bright_field'])
-    else:
-        nflat = dxreader._count_proj(dgroup, flat_name, nproj,
-                                     inter_bright=inter_bright)
-    if 'num_dark_fields' in keys:
-        ndark = int(dgroup.attrs['num_dark_fields'])
-    else:
-        ndark = dxreader._count_proj(dgroup, dark_name, nproj)
+        # Read metadata from dataset group attributes
+        keys = list(dgroup.attrs.keys())
+        if 'nangles' in keys:
+            nproj = int(dgroup.attrs['nangles'])
+        if 'i0cycle' in keys:
+            inter_bright = int(dgroup.attrs['i0cycle'])
+        if 'num_bright_field' in keys:
+            nflat = int(dgroup.attrs['num_bright_field'])
+        else:
+            nflat = dxreader._count_proj(dgroup, flat_name, nproj,
+                                         inter_bright=inter_bright)
+        if 'num_dark_fields' in keys:
+            ndark = int(dgroup.attrs['num_dark_fields'])
+        else:
+            ndark = dxreader._count_proj(dgroup, dark_name, nproj)
 
-    # Create arrays of indices to read projections, flats and darks
-    if ind_tomo is None:
-        ind_tomo = list(range(0, nproj))
-    ind_dark = list(range(0, ndark))
-    group_dark = [nproj - 1]
-    ind_flat = list(range(0, nflat))
+        # Create arrays of indices to read projections, flats and darks
+        if ind_tomo is None:
+            ind_tomo = list(range(0, nproj))
+        ind_dark = list(range(0, ndark))
+        group_dark = [nproj - 1]
+        ind_flat = list(range(0, nflat))
 
-    if inter_bright > 0:
-        group_flat = list(range(0, nproj, inter_bright))
-        if group_flat[-1] != nproj - 1:
-            group_flat.append(nproj - 1)
-    elif inter_bright == 0:
-        group_flat = [0, nproj - 1]
-    else:
-        group_flat = None
+        if inter_bright > 0:
+            group_flat = list(range(0, nproj, inter_bright))
+            if group_flat[-1] != nproj - 1:
+                group_flat.append(nproj - 1)
+        elif inter_bright == 0:
+            group_flat = [0, nproj - 1]
+        else:
+            group_flat = None
 
-    tomo = dxreader.read_hdf5_stack(
-        dgroup, tomo_name, ind_tomo, slc=(proj, sino))
+        tomo = dxreader.read_hdf5_stack(
+            dgroup, tomo_name, ind_tomo, slc=(proj, sino))
 
-    flat = dxreader.read_hdf5_stack(dgroup, flat_name, ind_flat, slc=(None, sino),
-                                    out_ind=group_flat)
+        flat = dxreader.read_hdf5_stack(dgroup, flat_name, ind_flat, slc=(None, sino),
+                                        out_ind=group_flat)
 
-    dark = dxreader.read_hdf5_stack(dgroup, dark_name, ind_dark, slc=(None, sino),
-                                    out_ind=group_dark)
+        dark = dxreader.read_hdf5_stack(dgroup, dark_name, ind_dark, slc=(None, sino),
+                                        out_ind=group_dark)
 
-    group_flat = dxreader._map_loc(ind_tomo, group_flat)
+        group_flat = dxreader._map_loc(ind_tomo, group_flat)
 
     if mult_flats:
         return tomo, flat, dark, group_flat

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -223,7 +223,7 @@ def read_als_832(fname, ind_tomo=None, normalized=False):
 
 
 def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
-                   proj=None, sino=None):
+                   proj=None, sino=None, mult_flats=False):
     """
     Read ALS 8.3.2 hdf5 file with stacked datasets.
 
@@ -247,6 +247,9 @@ def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
 
     sino : {sequence, int}, optional
         Specify sinograms to read. (start, end, step)
+
+    mult_flats: bool, optional
+        Will return a list of locations where flat fields where taken in dataset.
 
     Returns
     -------
@@ -280,7 +283,7 @@ def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
         nflat = int(dgroup.attrs['num_bright_field'])
     else:
         nflat = dxreader._count_proj(dgroup, flat_name, nproj,
-                                inter_bright=inter_bright)
+                                     inter_bright=inter_bright)
     if 'num_dark_fields' in keys:
         ndark = int(dgroup.attrs['num_dark_fields'])
     else:
@@ -313,7 +316,10 @@ def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
 
     group_flat = dxreader._map_loc(ind_tomo, group_flat)
 
-    return tomo, flat, dark, group_flat
+    if mult_flats:
+        return tomo, flat, dark, group_flat
+    else:
+        return tomo, flat, dark
 
 
 def read_anka_topotomo(

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -104,9 +104,6 @@ def read_als_832(fname, ind_tomo=None, normalized=False, sino=None):
         8.3.2 has a plugin that normalization is preferred to be
         done with prior to tomopy reconstruction.
 
-        proj : {sequence, int}, optional
-        Specify projections to read. (start, end, step)
-
     sino : {sequence, int}, optional
         Specify sinograms to read. (start, end, step)
 

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -107,9 +107,6 @@ def read_als_832(fname, ind_tomo=None, normalized=False, sino=None):
         proj : {sequence, int}, optional
         Specify projections to read. (start, end, step)
 
-    proj : {sequence, int}, optional
-        Specify projections to read. (start, end, step)
-
     sino : {sequence, int}, optional
         Specify sinograms to read. (start, end, step)
 

--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -616,8 +616,8 @@ def find_dataset_group(fname):
     -------
     h5py.Group
     """
-    h5object = h5py.File(fname, 'r')
-    yield _find_dataset_group(h5object)
+    with h5py.File(fname, 'r') as h5object:
+        yield _find_dataset_group(h5object)
 
 
 def _find_dataset_group(h5object):

--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -79,6 +79,7 @@ import logging
 import re
 import math
 import struct
+from contextlib import contextmanager
 import dxchange.writer as writer
 from dxchange.dtype import empty_shared_array
 
@@ -600,6 +601,7 @@ def _list_file_stack(fname, ind, digit):
         list_fname.append(str(body + '{0:0={1}d}'.format(m, digit) + ext))
     return list_fname
 
+@contextmanager
 def find_dataset_group(fname):
     """
     Finds the group name containing the stack of projections datasets within
@@ -615,7 +617,7 @@ def find_dataset_group(fname):
     h5py.Group
     """
     h5object = h5py.File(fname, 'r')
-    return _find_dataset_group(h5object)
+    yield _find_dataset_group(h5object)
 
 
 def _find_dataset_group(h5object):


### PR DESCRIPTION
Small fixes/enhancement include:
- ALS h5 reader returns only tomo, flat, dark (unless mult_flats flag is specified) #20
- ALS tiff datasets now work correctly #21 
- ALS tiff dataset reader now has sino slice keyword #22 
- ALS h5 files are handled in a context manager #24 as suggested by @tacaswell.
