### PR TITLE
Working on adding support for aps_8bm beamline.

### DIFF
--- a/doc/demo/rec_als.py
+++ b/doc/demo/rec_als.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     proj = tomopy.normalize(proj, flat, dark)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, init=1024, ind=0, tol=0.5)
+    rot_center = tomopy.find_center(proj, theta, init=1024, ind=0, tol=0.5)
     print("Center of rotation:", rot_center)
 
     proj = tomopy.minus_log(proj)

--- a/doc/demo/rec_als_hdf5.py
+++ b/doc/demo/rec_als_hdf5.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     proj = tomopy.normalize(proj, flat, dark)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, init=1024, ind=0, tol=0.5)
+    rot_center = tomopy.find_center(proj, theta, init=1024, ind=0, tol=0.5)
     print("Center of rotation:", rot_center)
 
     proj = tomopy.minus_log(proj)

--- a/doc/demo/rec_anka.py
+++ b/doc/demo/rec_anka.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     proj = tomopy.normalize(proj, flat, dark)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, init=1024,
+    rot_center = tomopy.find_center(proj, theta, init=1024,
                                     ind=0, tol=0.5)
     print("Center of rotation: ", rot_center)
 

--- a/doc/demo/rec_aps_1id.py
+++ b/doc/demo/rec_aps_1id.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     proj = tomopy.normalize(proj, flat, dark)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, init=1024, ind=0, tol=0.5)
+    rot_center = tomopy.find_center(proj, theta, init=1024, ind=0, tol=0.5)
     print("Center of rotation: ", rot_center)
 
     proj = tomopy.minus_log(proj)

--- a/doc/demo/rec_aps_32id_full.py
+++ b/doc/demo/rec_aps_32id_full.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     proj = tomopy.normalize(proj, flat, dark)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, ind=0, init=1024, tol=0.5)
+    rot_center = tomopy.find_center(proj, theta, ind=0, init=1024, tol=0.5)
     print("Center of rotation: ", rot_center)
 
     proj = tomopy.minus_log(proj)

--- a/doc/demo/rec_elettra.py
+++ b/doc/demo/rec_elettra.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     proj = tomopy.normalize(proj, flat, dark)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, init=1024, ind=0, tol=0.5)
+    rot_center = tomopy.find_center(proj, theta, init=1024, ind=0, tol=0.5)
     print("Center of rotation: ", rot_center)
 
     proj = tomopy.minus_log(proj)

--- a/doc/demo/rec_esrf.py
+++ b/doc/demo/rec_esrf.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     proj = tomopy.normalize(proj, flat, dark)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, init=1024,
+    rot_center = tomopy.find_center(proj, theta, init=1024,
                                     ind=0, tol=0.5)
     print("Center of rotation: ", rot_center)
 

--- a/doc/demo/rec_tomcat.py
+++ b/doc/demo/rec_tomcat.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     proj = tomopy.normalize(proj, flat, dark)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, init=1024,
+    rot_center = tomopy.find_center(proj, theta, init=1024,
                                     ind=0, tol=0.5)
     print("Center of rotation:", rot_center)
 

--- a/doc/demo/rec_xradia_xrm.py
+++ b/doc/demo/rec_xradia_xrm.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     proj = tomopy.normalize(proj, flat, dark)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, init=1024,
+    rot_center = tomopy.find_center(proj, theta, init=1024,
                                     ind=0, tol=0.5)
     print("Center of rotation: ", rot_center)
 

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -509,6 +509,12 @@ def read_aps_8bm(image_directory, tomo_indices, flat_indices, image_file_pattern
     file_digits: int
         Number of digits in the filename counter.
         
+    image_file_pattern: string
+        Specify how the projection files are named.
+    
+    flat_file_pattern: string
+        Specify how the flat reference files are named.
+    
     proj : {sequence, int}, optional
         Specify projections to read. (start, end, step)
 

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -491,7 +491,7 @@ def read_aps_7bm(fname, proj=None, sino=None):
     theta = dxreader.read_hdf5(fname, theta_grp, slc=(proj, ))
     return tomo, theta
 
-def read_aps_8bm(image_directory, tomo_indices, flat_indices, file_pattern='image_00000.xrm', file_digits=5, proj=None, sino=None):
+def read_aps_8bm(image_directory, tomo_indices, flat_indices, image_file_pattern='image_00000.xrm', flat_file_pattern='ref_00000.xrm', proj=None, sino=None):
     """
     Read APS 8-BM tomography data from a stack of xrm files.
     
@@ -524,13 +524,14 @@ def read_aps_8bm(image_directory, tomo_indices, flat_indices, file_pattern='imag
         3D flat field data.
     """
     image_directory = os.path.abspath(image_directory)
-    tomo_name = os.path.join(image_directory, 'radios', file_pattern)
-    flat_name = os.path.join(image_directory, 'flats', file_pattern)
+    tomo_name = os.path.join(image_directory, 'radios', image_file_pattern)
+    flat_name = os.path.join(image_directory, 'flats', flat_file_pattern)
 
     tomo = dxreader.read_xrm_stack(
-        tomo_name, ind=tomo_indices, digit=file_digits, slc=(sino, proj))
+        tomo_name, ind=tomo_indices, slc=(sino, proj))
+    
     flat = dxreader.read_xrm_stack(
-        flat_name, ind=flat_indices, digit=file_digits, slc=(sino, None))
+        flat_name, ind=flat_indices, slc=(sino, None))
     return tomo, flat
 
 def read_aps_13bm(fname, format, proj=None, sino=None):

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -64,6 +64,7 @@ __all__ = ['read_als_832',
            'read_aps_1id',
            'read_aps_2bm',
            'read_aps_7bm',
+           'read_aps_8bm',
            'read_aps_13bm',
            'read_aps_13id',
            'read_aps_26id',
@@ -98,7 +99,7 @@ def read_als_832(fname, ind_tomo=None, normalized=False, sino=None):
     ind_tomo : list of int, optional
         Indices of the projection files to read.
 
-    normalized : boolean
+    normalized : boolean, optional
         If False, darks and flats will not be read. This should
         only be used for cases where tomo is already normalized.
         8.3.2 has a plugin that normalization is preferred to be
@@ -327,10 +328,10 @@ def read_anka_topotomo(
     fname : str
         Path to data folder name without indices and extension.
 
-    ind_tomo : list of int, optional
+    ind_tomo : list of int
         Indices of the projection files to read.
 
-    ind_flat : list of int, optional
+    ind_flat : list of int
         Indices of the flat field files to read.
 
     ind_dark : list of int, optional
@@ -490,6 +491,47 @@ def read_aps_7bm(fname, proj=None, sino=None):
     theta = dxreader.read_hdf5(fname, theta_grp, slc=(proj, ))
     return tomo, theta
 
+def read_aps_8bm(image_directory, tomo_indices, flat_indices, file_pattern='image_00000.xrm', file_digits=5, proj=None, sino=None):
+    """
+    Read APS 8-BM tomography data from a stack of xrm files.
+    
+    Parameters
+    ----------
+    image_directory : str
+        Path to data folder name without indices and extension.
+
+    tomo_indices : list of int
+        Indices of the projection files to read.
+
+    flat_indices : list of int
+        Indices of the flat field files to read.
+    
+    file_digits: int
+        Number of digits in the filename counter.
+        
+    proj : {sequence, int}, optional
+        Specify projections to read. (start, end, step)
+
+    sino : {sequence, int}, optional
+        Specify sinograms to read. (start, end, step)
+
+    Returns
+    -------
+    ndarray
+        3D tomographic data.
+
+    ndarray
+        3D flat field data.
+    """
+    image_directory = os.path.abspath(image_directory)
+    tomo_name = os.path.join(image_directory, 'radios', file_pattern)
+    flat_name = os.path.join(image_directory, 'flats', file_pattern)
+
+    tomo = dxreader.read_xrm_stack(
+        tomo_name, ind=tomo_indices, digit=file_digits, slc=(sino, proj))
+    flat = dxreader.read_xrm_stack(
+        flat_name, ind=flat_indices, digit=file_digits, slc=(sino, None))
+    return tomo, flat
 
 def read_aps_13bm(fname, format, proj=None, sino=None):
     """
@@ -562,10 +604,10 @@ def read_aps_26id(fname, ind_tomo, ind_flat, proj=None, sino=None):
     fname : str
         Path to data folder name without indices and extension.
 
-    ind_tomo : list of int, optional
+    ind_tomo : list of int
         Indices of the projection files to read.
 
-    ind_flat : list of int, optional
+    ind_flat : list of int
         Indices of the flat field files to read.
 
     proj : {sequence, int}, optional

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -653,7 +653,7 @@ def read_aps_32id(fname, exchange_rank=0, proj=None, sino=None):
 
     exchange_rank : int, optional
         exchange_rank is added to "exchange" to point tomopy to the data
-        to recontruct. if rank is not set then the data are raw from the
+        to reconstruct. if rank is not set then the data are raw from the
         detector and are located under exchange = "exchange/...", to process
         data that are the result of some intemedite processing step then
         exchange_rank = 1, 2, ... will direct tomopy to process

--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -83,6 +83,7 @@ import struct
 from contextlib import contextmanager
 import dxchange.writer as writer
 from dxchange.dtype import empty_shared_array
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +146,7 @@ def read_tiff(fname, slc=None):
     return arr
 
 
-def read_tiff_stack(fname, ind, digit, slc=None):
+def read_tiff_stack(fname, ind, digit=None, slc=None):
     """
     Read data from stack of tiff files in a folder.
 
@@ -156,7 +157,7 @@ def read_tiff_stack(fname, ind, digit, slc=None):
     ind : list of int
         Indices of the files to read.
     digit : int
-        Number of digits used in indexing stacked files.
+        (Deprecated) Number of digits used in indexing stacked files.
     slc : sequence of tuples, optional
         Range of values for slicing data in each axis.
         ((start_1, end_1, step_1), ... , (start_N, end_N, step_N))
@@ -633,7 +634,7 @@ def _shape_after_slice(shape, slc):
     return tuple(new_shape)
 
 
-def _list_file_stack(fname, ind):
+def _list_file_stack(fname, ind, digit=None):
     """
     Return a stack of file names in a folder as a list.
 
@@ -644,9 +645,15 @@ def _list_file_stack(fname, ind):
     ind : list of int
         Indices of the files to read.
     digit : int
-        Number of digits in indexing stacked files.
+        Deprecated input for the number of digits in all indexes 
+        of the stacked files.
     """
 
+    if (digit is not None):
+        warnings.warn(("The 'digit' argument is deprecated and no longer used."  
+                      "  It may be removed completely in a later version."),
+                      FutureWarning)
+                      
     body = writer.get_body(fname)
     body, digits = writer.remove_trailing_digits(body)
     
@@ -779,7 +786,7 @@ def read_hdf5_stack(h5group, dname, ind, digit=4, slc=None, out_ind=None):
         Indices of the datasets to be read
 
     digit : int
-        Number of digits indexing the stacked datasets
+        (Deprecated) Number of digits indexing the stacked datasets
 
     slc : {sequence, int}
         Range of values for slicing data.

--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -580,7 +580,7 @@ def _shape_after_slice(shape, slc):
     return tuple(new_shape)
 
 
-def _list_file_stack(fname, ind, digit):
+def _list_file_stack(fname, ind):
     """
     Return a stack of file names in a folder as a list.
 
@@ -594,11 +594,14 @@ def _list_file_stack(fname, ind, digit):
         Number of digits in indexing stacked files.
     """
 
-    body = writer.get_body(fname, digit)
+    body = writer.get_body(fname)
+    body, digits = writer.remove_trailing_digits(body)
+    
     ext = writer.get_extension(fname)
     list_fname = []
     for m in ind:
-        list_fname.append(str(body + '{0:0={1}d}'.format(m, digit) + ext))
+        counter_string = str(m).zfill(digits)
+        list_fname.append(body + counter_string + ext)
     return list_fname
 
 @contextmanager

--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -68,6 +68,7 @@ __all__ = ['read_edf',
            'read_tiff_stack',
            'read_xrm',
            'read_xrm_stack',
+           'read_txrm',
            'read_hdf5_stack']
 
 
@@ -105,7 +106,7 @@ olefile = _check_import('olefile')
 # is very useful, unless we are automatically mapping an extension to a
 # function.
 def _check_read(fname):
-    known_extensions = ['.edf', '.tiff', '.tif', '.h5', '.hdf', '.npy', '.xrm']
+    known_extensions = ['.edf', '.tiff', '.tif', '.h5', '.hdf', '.npy', '.xrm', '.txrm']
     if not isinstance(fname, six.string_types):
         logger.error('File name must be a string')
     else:
@@ -211,13 +212,12 @@ def read_xrm(fname, slc=None):
     elif d_type == 5:                   
         struct_fmt = "<{}h".format(n_cols*n_rows)
     
-    img = _read_data(ole, "ImageData1/Image1", struct_fmt)
+    img = _read_ole_data(ole, "ImageData1/Image1", struct_fmt)
 
     arr = np.zeros((n_cols, n_rows))    
     arr[:,:] = np.reshape(img, (n_cols, n_rows), order='F')
     arr = np.swapaxes(arr,0,1)
-
-    arr = _slice_array(arr, slc)  
+    arr = _slice_array(arr, slc)
     _log_imported_data(fname, arr)
     return arr
 
@@ -249,6 +249,62 @@ def read_xrm_stack(fname, ind, slc=None):
         arr[m] = read_xrm(fname, slc)
     _log_imported_data(fname, arr)
     return arr
+
+def read_txrm(file_name, slice_range=None):
+    """
+    Read data from a txrm file, a compilation of xrm files.
+  
+    Parameters
+    ----------
+    file_name : str
+        String defining the path of file or file name.
+    slice_range : sequence of tuples, optional
+        Range of values for slicing data in each axis.
+        ((start_1, end_1, step_1), ... , (start_N, end_N, step_N))
+        defines slicing parameters for each axis of the data matrix.
+  
+    Returns
+    -------
+    ndarray
+        Output 2D image.
+    """
+    file_name = _check_read(file_name)
+    try:
+        import olefile
+        ole = olefile.OleFileIO(file_name)
+    except IOError:
+        print('No such file or directory: %s', file_name)
+        return False
+    
+    number_of_columns = _read_label(ole, 'ImageInfo/ImageWidth', '<I')
+    number_of_rows = _read_label(ole, 'ImageInfo/ImageHeight', '<I')
+    data_type = _read_label(ole, 'ImageInfo/DataType', '<1I')
+
+    number_of_images = _read_ole_data(ole, "ImageInfo/NoOfImages", "<I")[0]
+    
+    image_info_array = np.empty((number_of_columns, number_of_rows, number_of_images), dtype=np.float32)
+    for i in range(1, number_of_images+1):
+        img_string = "ImageData{}/Image{}".format(int(np.ceil(i/100.0)), int(i))
+        stream = ole.openstream(img_string)
+        data = stream.read()
+        # 10 float; 5 uint16 (unsigned 16-bit (2-byte) integers)
+        if data_type == 10:
+            struct_fmt = "<{}f".format(number_of_columns*number_of_rows)
+        elif data_type == 5:
+            struct_fmt = "<{}h".format(number_of_columns*number_of_rows)
+        else:                            
+            print("Wrong data type")
+            return False
+        
+        image_info_array[:,:,i-1] = np.reshape(struct.unpack(struct_fmt, data), (number_of_columns, number_of_rows), order='F')
+    
+    image_info_array = np.swapaxes(image_info_array,1,2)
+    
+    image_info_array = _slice_array(image_info_array, slice_range)
+    _log_imported_data(file_name, image_info_array)
+    
+    ole.close()
+    return image_info_array
     
 def _log_imported_data(fname, arr):
     logger.debug('Data shape & type: %s %s', arr.shape, arr.dtype)
@@ -696,7 +752,7 @@ def _read_label(ole, label, struct_fmt):
     
     return value
 
-def _read_data(ole, label, struct_fmt):
+def _read_ole_data(ole, label, struct_fmt):
     """
     Reads the array associated with label in an ole file
     """

--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -221,7 +221,7 @@ def read_xrm(fname, slc=None):
     _log_imported_data(fname, arr)
     return arr
 
-def read_xrm_stack(fname, ind, digit, slc=None):
+def read_xrm_stack(fname, ind, slc=None):
     """
     Read data from stack of xrm files in a folder.
 
@@ -231,8 +231,6 @@ def read_xrm_stack(fname, ind, digit, slc=None):
         One of the file names in the tiff stack.
     ind : list of int
         Indices of the files to read.
-    digit : int
-        Number of digits used in indexing stacked files.
     slc : sequence of tuples, optional
         Range of values for slicing data in each axis.
         ((start_1, end_1, step_1), ... , (start_N, end_N, step_N))
@@ -244,18 +242,17 @@ def read_xrm_stack(fname, ind, digit, slc=None):
         Output 3D image.
     """
     fname = _check_read(fname)
-    list_fname = _list_file_stack(fname, ind, digit)
+    list_fname = _list_file_stack(fname, ind)
 
     arr = _init_ole_arr_from_stack(list_fname[0], len(ind), slc)
     for m, fname in enumerate(list_fname):
         arr[m] = read_xrm(fname, slc)
     _log_imported_data(fname, arr)
     return arr
-
-
+    
 def _log_imported_data(fname, arr):
     logger.debug('Data shape & type: %s %s', arr.shape, arr.dtype)
-    logger.info('Data succesfully imported: %s', fname)
+    logger.info('Data successfully imported: %s', fname)
 
 
 def _init_arr_from_stack(fname, nfile, slc):

--- a/dxchange/writer.py
+++ b/dxchange/writer.py
@@ -71,6 +71,7 @@ import os
 import six
 import h5py
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -85,13 +86,11 @@ def _check_import(modname):
 dxfile = _check_import('dxfile')
 
 
-def get_body(fname, digit=None):
+def get_body(fname):
     """
     Get file name after extension removed.
     """
     body = os.path.splitext(fname)[0]
-    if digit is not None:
-        body = ''.join(body[:-digit])
     return body
 
 
@@ -101,7 +100,14 @@ def get_extension(fname):
     """
     return '.' + fname.split(".")[-1]
 
-
+def remove_trailing_digits(text):
+    number_of_digits = len(re.search('\d+$', text).group()) #get the number of digits at the end of the filename
+    print(text)
+    print(number_of_digits)
+    text = ''.join(text[:-number_of_digits])
+    return (text, number_of_digits)
+    
+    
 def _init_dirs(fname):
     """
     Initialize directories for saving output files.

--- a/dxchange/writer.py
+++ b/dxchange/writer.py
@@ -101,9 +101,15 @@ def get_extension(fname):
     return '.' + fname.split(".")[-1]
 
 def remove_trailing_digits(text):
-    number_of_digits = len(re.search('\d+$', text).group()) #get the number of digits at the end of the filename
-    text = ''.join(text[:-number_of_digits])
-    return (text, number_of_digits)
+    digit_string = re.search('\d+$', text)
+    if digit_string is not None:
+        number_of_digits = len(digit_string.group()) #get the number of digits at the end of the filename
+        text = ''.join(text[:-number_of_digits])
+        return (text, number_of_digits)
+    else:
+        return (text, 0)
+        
+    
     
     
 def _init_dirs(fname):

--- a/dxchange/writer.py
+++ b/dxchange/writer.py
@@ -102,8 +102,6 @@ def get_extension(fname):
 
 def remove_trailing_digits(text):
     number_of_digits = len(re.search('\d+$', text).group()) #get the number of digits at the end of the filename
-    print(text)
-    print(number_of_digits)
     text = ''.join(text[:-number_of_digits])
     return (text, number_of_digits)
     

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# #########################################################################
+# Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.         #
+#                                                                         #
+# Copyright 2015. UChicago Argonne, LLC. This software was produced       #
+# under U.S. Government contract DE-AC02-06CH11357 for Argonne National   #
+# Laboratory (ANL), which is operated by UChicago Argonne, LLC for the    #
+# U.S. Department of Energy. The U.S. Government has rights to use,       #
+# reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR    #
+# UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR        #
+# ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is     #
+# modified to produce derivative works, such modified software should     #
+# be clearly marked, so as not to confuse it with the version available   #
+# from ANL.                                                               #
+#                                                                         #
+# Additionally, redistribution and use in source and binary forms, with   #
+# or without modification, are permitted provided that the following      #
+# conditions are met:                                                     #
+#                                                                         #
+#     * Redistributions of source code must retain the above copyright    #
+#       notice, this list of conditions and the following disclaimer.     #
+#                                                                         #
+#     * Redistributions in binary form must reproduce the above copyright #
+#       notice, this list of conditions and the following disclaimer in   #
+#       the documentation and/or other materials provided with the        #
+#       distribution.                                                     #
+#                                                                         #
+#     * Neither the name of UChicago Argonne, LLC, Argonne National       #
+#       Laboratory, ANL, the U.S. Government, nor the names of its        #
+#       contributors may be used to endorse or promote products derived   #
+#       from this software without specific prior written permission.     #
+#                                                                         #
+# THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS     #
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT       #
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS       #
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago     #
+# Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,        #
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,    #
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;        #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER        #
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT      #
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN       #
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         #
+# POSSIBILITY OF SUCH DAMAGE.                                             #
+# #########################################################################
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)

--- a/test/test_dxchange/__init__.py
+++ b/test/test_dxchange/__init__.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# #########################################################################
+# Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.         #
+#                                                                         #
+# Copyright 2015. UChicago Argonne, LLC. This software was produced       #
+# under U.S. Government contract DE-AC02-06CH11357 for Argonne National   #
+# Laboratory (ANL), which is operated by UChicago Argonne, LLC for the    #
+# U.S. Department of Energy. The U.S. Government has rights to use,       #
+# reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR    #
+# UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR        #
+# ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is     #
+# modified to produce derivative works, such modified software should     #
+# be clearly marked, so as not to confuse it with the version available   #
+# from ANL.                                                               #
+#                                                                         #
+# Additionally, redistribution and use in source and binary forms, with   #
+# or without modification, are permitted provided that the following      #
+# conditions are met:                                                     #
+#                                                                         #
+#     * Redistributions of source code must retain the above copyright    #
+#       notice, this list of conditions and the following disclaimer.     #
+#                                                                         #
+#     * Redistributions in binary form must reproduce the above copyright #
+#       notice, this list of conditions and the following disclaimer in   #
+#       the documentation and/or other materials provided with the        #
+#       distribution.                                                     #
+#                                                                         #
+#     * Neither the name of UChicago Argonne, LLC, Argonne National       #
+#       Laboratory, ANL, the U.S. Government, nor the names of its        #
+#       contributors may be used to endorse or promote products derived   #
+#       from this software without specific prior written permission.     #
+#                                                                         #
+# THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS     #
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT       #
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS       #
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago     #
+# Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,        #
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,    #
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;        #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER        #
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT      #
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN       #
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         #
+# POSSIBILITY OF SUCH DAMAGE.                                             #
+# #########################################################################
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)

--- a/test/test_dxchange/test_reader.py
+++ b/test/test_dxchange/test_reader.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# #########################################################################
+# Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.         #
+#                                                                         #
+# Copyright 2015. UChicago Argonne, LLC. This software was produced       #
+# under U.S. Government contract DE-AC02-06CH11357 for Argonne National   #
+# Laboratory (ANL), which is operated by UChicago Argonne, LLC for the    #
+# U.S. Department of Energy. The U.S. Government has rights to use,       #
+# reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR    #
+# UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR        #
+# ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is     #
+# modified to produce derivative works, such modified software should     #
+# be clearly marked, so as not to confuse it with the version available   #
+# from ANL.                                                               #
+#                                                                         #
+# Additionally, redistribution and use in source and binary forms, with   #
+# or without modification, are permitted provided that the following      #
+# conditions are met:                                                     #
+#                                                                         #
+#     * Redistributions of source code must retain the above copyright    #
+#       notice, this list of conditions and the following disclaimer.     #
+#                                                                         #
+#     * Redistributions in binary form must reproduce the above copyright #
+#       notice, this list of conditions and the following disclaimer in   #
+#       the documentation and/or other materials provided with the        #
+#       distribution.                                                     #
+#                                                                         #
+#     * Neither the name of UChicago Argonne, LLC, Argonne National       #
+#       Laboratory, ANL, the U.S. Government, nor the names of its        #
+#       contributors may be used to endorse or promote products derived   #
+#       from this software without specific prior written permission.     #
+#                                                                         #
+# THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS     #
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT       #
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS       #
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago     #
+# Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,        #
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,    #
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;        #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER        #
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT      #
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN       #
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         #
+# POSSIBILITY OF SUCH DAMAGE.                                             #
+# #########################################################################
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from numpy.testing.utils import assert_equal
+from dxchange import reader 
+
+def test_list_file_stack_one_digit():
+    file_stack = reader._list_file_stack("path/image_0.xrm", [1,2])
+    assert_equal(file_stack, ["path/image_1.xrm", "path/image_2.xrm"])
+
+def test_list_file_stack_five_digits():
+    file_stack = reader._list_file_stack("someFile/someOtherFile/imageOfSorts_00000.xrm", [1,2])
+    assert_equal(file_stack, ["someFile/someOtherFile/imageOfSorts_00001.xrm", "someFile/someOtherFile/imageOfSorts_00002.xrm"])
+
+def test_list_file_stack_ten_digits():
+    file_stack = reader._list_file_stack("path/image_0000000000.xrm", [1,2])
+    assert_equal(file_stack, ["path/image_0000000001.xrm", "path/image_0000000002.xrm"])
+    
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(exit=False)

--- a/test/test_dxchange/test_reader.py
+++ b/test/test_dxchange/test_reader.py
@@ -51,6 +51,9 @@ from __future__ import (absolute_import, division, print_function,
 
 from numpy.testing.utils import assert_equal
 from dxchange import reader 
+import numpy
+import os
+
 
 def test_list_file_stack_one_digit():
     file_stack = reader._list_file_stack("path/image_0.xrm", [1,2])
@@ -63,6 +66,10 @@ def test_list_file_stack_five_digits():
 def test_list_file_stack_ten_digits():
     file_stack = reader._list_file_stack("path/image_0000000000.xrm", [1,2])
     assert_equal(file_stack, ["path/image_0000000001.xrm", "path/image_0000000002.xrm"])
+    
+def test_list_file_stack_underscore_split_digits():
+    file_stack = reader._list_file_stack("path/image_00000_00000.xrm", [1,2])
+    numpy.testing.utils.assert_equal(file_stack, ["path/image_00000_00001.xrm", "path/image_00000_00002.xrm"])
     
 if __name__ == '__main__':
     import nose

--- a/test/test_dxchange/test_writer.py
+++ b/test/test_dxchange/test_writer.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# #########################################################################
+# Copyright (c) 2015, UChicago Argonne, LLC. All rights reserved.         #
+#                                                                         #
+# Copyright 2015. UChicago Argonne, LLC. This software was produced       #
+# under U.S. Government contract DE-AC02-06CH11357 for Argonne National   #
+# Laboratory (ANL), which is operated by UChicago Argonne, LLC for the    #
+# U.S. Department of Energy. The U.S. Government has rights to use,       #
+# reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR    #
+# UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR        #
+# ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is     #
+# modified to produce derivative works, such modified software should     #
+# be clearly marked, so as not to confuse it with the version available   #
+# from ANL.                                                               #
+#                                                                         #
+# Additionally, redistribution and use in source and binary forms, with   #
+# or without modification, are permitted provided that the following      #
+# conditions are met:                                                     #
+#                                                                         #
+#     * Redistributions of source code must retain the above copyright    #
+#       notice, this list of conditions and the following disclaimer.     #
+#                                                                         #
+#     * Redistributions in binary form must reproduce the above copyright #
+#       notice, this list of conditions and the following disclaimer in   #
+#       the documentation and/or other materials provided with the        #
+#       distribution.                                                     #
+#                                                                         #
+#     * Neither the name of UChicago Argonne, LLC, Argonne National       #
+#       Laboratory, ANL, the U.S. Government, nor the names of its        #
+#       contributors may be used to endorse or promote products derived   #
+#       from this software without specific prior written permission.     #
+#                                                                         #
+# THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS     #
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT       #
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS       #
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago     #
+# Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,        #
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,    #
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;        #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER        #
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT      #
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN       #
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         #
+# POSSIBILITY OF SUCH DAMAGE.                                             #
+# #########################################################################
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from numpy.testing.utils import assert_equal
+import dxchange.writer as writer
+
+def test_remove_trailing_digits_removes_zeroes():
+    text, digits = writer.remove_trailing_digits("someText0000")
+    assert_equal(text, "someText")
+
+def test_remove_trailing_digits_removes_correct_number_of_zeroes():
+    text, digits = writer.remove_trailing_digits("someText0000")
+    assert_equal(digits, 4)
+    
+def test_remove_trailing_digits_removes_digits():
+    text, digits = writer.remove_trailing_digits("someText12345678900987654321")
+    assert_equal(text, "someText")
+    
+def test_remove_trailing_digits_does_not_remove_digits_in_the_middle():
+    text, digits = writer.remove_trailing_digits("8s7o6m5e4T3e2x1t000.0000")
+    assert_equal(text, "8s7o6m5e4T3e2x1t000.")
+    
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(exit=False)

--- a/test/test_dxchange/test_writer.py
+++ b/test/test_dxchange/test_writer.py
@@ -52,6 +52,11 @@ from __future__ import (absolute_import, division, print_function,
 from numpy.testing.utils import assert_equal
 import dxchange.writer as writer
 
+
+def test_remove_trailing_digits_handles_not_having_digits():
+    text, digits = writer.remove_trailing_digits("someText")
+    assert_equal(text, "someText")
+    
 def test_remove_trailing_digits_removes_zeroes():
     text, digits = writer.remove_trailing_digits("someText0000")
     assert_equal(text, "someText")


### PR DESCRIPTION
Code review welcome.  

tomopy.find_center() no longer has an emission argument, so I assume the reconstruction scripts that were sending it one were out of date?

I'm not sure that this beamline shouldn't just be referencing another one in the way read_aps_2bm() is.
