### PR TITLE
return group_flat from ALS832 reader

### DIFF
--- a/doc/demo/rec_als_hdf5.py
+++ b/doc/demo/rec_als_hdf5.py
@@ -19,16 +19,16 @@ if __name__ == '__main__':
     end = 16
 
     # Read the ALS raw data.
-    proj, flat, dark = dxchange.read_als_832h5(fname, sino=(start, end))
+    proj, flat, dark, grp_flat = dxchange.read_als_832h5(fname, sino=(start, end))
 
     # Set data collection angles as equally spaced between 0-180 degrees.
     theta = tomopy.angles(proj.shape[0], 0, 180)
 
     # Flat-field correction of raw data.
-    proj = tomopy.normalize(proj, flat, dark)
+    proj = tomopy.normalize_nf(proj, flat, dark, grp_flat)
 
     # Find rotation center.
-    rot_center = tomopy.find_center(proj, theta, emission=False, init=1024, ind=0, tol=0.5)
+    rot_center = tomopy.find_center(proj, theta, init=1024, ind=0, tol=0.5)
     print("Center of rotation:", rot_center)
 
     proj = tomopy.minus_log(proj)

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -314,7 +314,7 @@ def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
         dark = dxreader.read_hdf5_stack(dgroup, dark_name, ind_dark, slc=(None, sino),
                                         out_ind=group_dark)
 
-    return tomo, flat, dark
+    return tomo, flat, dark, group_flat
 
 
 def read_anka_topotomo(

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -314,7 +314,7 @@ def read_als_832h5(fname, ind_tomo=None, ind_flat=None, ind_dark=None,
         dark = dxreader.read_hdf5_stack(dgroup, dark_name, ind_dark, slc=(None, sino),
                                         out_ind=group_dark)
 
-    return tomo, flat, dark, group_flat
+    return tomo, flat, dark, dxreader._map_loc(ind_tomo, group_flat)
 
 
 def read_anka_topotomo(

--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -675,7 +675,7 @@ def _map_loc(ind, loc):
     min_loc = low - buff
     max_loc = upp + buff
     loc = np.intersect1d(loc[loc > min_loc], loc[loc < max_loc])
-    new_upp = len(ind)
+    new_upp = len(ind) - 1
     loc = (new_upp * (loc - low)) // (upp - low)
     if loc[0] < 0:
         loc[0] = 0

--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -744,7 +744,7 @@ def read_hdf5_stack(h5group, dname, ind, digit=4, slc=None, out_ind=None):
             fname = (writer.get_body(name).split('/')[-1] + '_' + digit * '0' +
                      writer.get_extension(name))
             list_fname_.extend(_list_file_stack(fname, out_ind, digit))
-        list_fname = list_fname_
+        list_fname = sorted(list_fname_, key=lambda x: str(x).split('_')[-1])
 
     for m, image in enumerate(list_fname):
         _arr = h5group[image]


### PR DESCRIPTION
Changing this back to return the flat field grouping. Any tests to the function must unpack 4 values:
`proj, flat, dark, grp_flat = read_als832h5('filename')`