### PR TITLE
Add generic reader for a list of image files

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -15,7 +15,8 @@ requirements:
  
   run:
     - python
-    - numpy    
+    - numpy
+    - scipy    
     - h5py    
     - six    
     - netcdf4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 python
 numpy    
+scipy
 h5py    
 six    
 netcdf4


### PR DESCRIPTION
This PR adds support for reading in a list of image file names into a single 3D array, using `dxchange.read_file_list`. It supports TIFF files through `tifffile`, and other image formats through `scipy.misc.imread`.

There is some existing support for this type of operation in `dxchange.read_tiff_stack` etcetera, but those only work if the file names are in a specific format (e.g. with digits at the end of the file names, and without any missing files). In some cases, we might want to read in files with names of a different format.

The method of the current PR is very generic, as it will accept any list of file names. This way, the user can read any file name format they want, but they will have to make sure that the list is in the order that they want to read it in. 

It might be possible to rewrite the existing `read_tiff_stack` to generate a list and call `read_file_list` afterwards (reducing code duplication). Currently, `read_tiff_stack` supports more features than `read_file_list` though, so that will require some extra work in the future. 
