### PR TITLE
HDF5 reader defaults to no shared memory and add dtype parameter to aps32ID read.

### DIFF
--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -642,7 +642,7 @@ def read_aps_26id(image_directory, tomo_indices, flat_indices,
                         image_file_pattern, flat_file_pattern, proj, sino)
 
 
-def read_aps_32id(fname, exchange_rank=0, proj=None, sino=None):
+def read_aps_32id(fname, exchange_rank=0, proj=None, sino=None, dtype=None):
     """
     Read APS 32-ID standard data format.
 
@@ -685,10 +685,10 @@ def read_aps_32id(fname, exchange_rank=0, proj=None, sino=None):
     flat_grp = '/'.join([exchange_base, 'data_white'])
     dark_grp = '/'.join([exchange_base, 'data_dark'])
     theta_grp = '/'.join([exchange_base, 'theta'])
-    tomo = dxreader.read_hdf5(fname, tomo_grp, slc=(proj, sino))
-    flat = dxreader.read_hdf5(fname, flat_grp, slc=(None, sino))
-    dark = dxreader.read_hdf5(fname, dark_grp, slc=(None, sino))
-    theta = dxreader.read_hdf5(fname, theta_grp, slc=None)
+    tomo = dxreader.read_hdf5(fname, tomo_grp, slc=(proj, sino), dtype=dtype)
+    flat = dxreader.read_hdf5(fname, flat_grp, slc=(None, sino), dtype=dtype)
+    dark = dxreader.read_hdf5(fname, dark_grp, slc=(None, sino), dtype=dtype)
+    theta = dxreader.read_hdf5(fname, theta_grp, slc=None, dtype=dtype)
 
     if (theta is None):
         pass

--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -665,6 +665,9 @@ def read_aps_32id(fname, exchange_rank=0, proj=None, sino=None, dtype=None):
     sino : {sequence, int}, optional
         Specify sinograms to read. (start, end, step)
 
+    dtype : numpy datatype, optional
+        Convert data to this datatype on read if specified.    
+
     Returns
     -------
     ndarray
@@ -688,7 +691,7 @@ def read_aps_32id(fname, exchange_rank=0, proj=None, sino=None, dtype=None):
     tomo = dxreader.read_hdf5(fname, tomo_grp, slc=(proj, sino), dtype=dtype)
     flat = dxreader.read_hdf5(fname, flat_grp, slc=(None, sino), dtype=dtype)
     dark = dxreader.read_hdf5(fname, dark_grp, slc=(None, sino), dtype=dtype)
-    theta = dxreader.read_hdf5(fname, theta_grp, slc=None, dtype=dtype)
+    theta = dxreader.read_hdf5(fname, theta_grp, slc=None)
 
     if (theta is None):
         pass

--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -482,7 +482,7 @@ def read_edf(fname, slc=None):
     return arr
 
 
-def read_hdf5(fname, dataset, slc=None, dtype=None, shared=True):
+def read_hdf5(fname, dataset, slc=None, dtype=None, shared=False):
     """
     Read data from hdf5 file from a specific group.
 


### PR DESCRIPTION
Default HDF5 reader to read into normal memory instead of shared memory.  We are removing multiprocessing from tomopy and it is better to not default to shared memory.

Add dtype parameter to reading from APS 32ID.  This allows the type to be specified during the read (and should probably be added to the other beam lines as well).