### PR TITLE
Use NullHandler instead of basicConfig

### DIFF
--- a/dxchange/__init__.py
+++ b/dxchange/__init__.py
@@ -50,7 +50,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import logging
-logging.basicConfig()
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 from dxchange.exchange import *
 from dxchange.reader import *


### PR DESCRIPTION
`logging.basicConfig()` was propably added to avoid the dreaded "no log handler found for ..." messages however this is the wrong approach because it interferes with the log handling in applications using the library, instead libraries should never set up log handlers and leave it to client application. To avoid
the message, libraries can register the `NullHandler` though, see for example:

  http://docs.python-guide.org/en/latest/writing/logging/#logging-in-a-library