### PR TITLE
Set maxshape to maxsize

### DIFF
--- a/dxchange/writer.py
+++ b/dxchange/writer.py
@@ -242,7 +242,8 @@ def write_hdf5(
         overwrite = True  # True if appending to file so fname is not changed
         maxshape = list(data.shape)
         maxshape[appendaxis] = maxsize
-
+    else:
+        maxshape = maxsize
     fname, data = _init_write(data, fname, '.h5', dtype, overwrite)
 
     with h5py.File(fname, mode=mode) as f:


### PR DESCRIPTION
maxshape has to be always defined to avoid crash of the
function write_hdf5. Set maxshape to maxsize in case 
where appendaxis is None.