### PR TITLE
Fixed Format String to be Python 2/3 Compatible

### DIFF
--- a/dxchange/exchange.py
+++ b/dxchange/exchange.py
@@ -424,7 +424,7 @@ def read_aps_1id(fname, ind_tomo=None, proj=None, sino=None, layer=0):
     try:
         _layerdf = _metadf[_metadf['layerID'] == layer]
     except:
-        print(f"Valid layers for reconstruction are: {_metadf['layerID'].unique()}")
+        print("Valid layers for reconstruction are: {}".format(_metadf['layerID'].unique()))
 
     # -- queery image data meta for given layer
     # still/projection images


### PR DESCRIPTION
Line 427 of exchange.py was throwing a SyntaxError on any import for Python 2.7.14 compiled for Xeon Phi. I'm not sure about other Python 2.7 installs, but the `f"foo"` format string wasn't recognized as valid Python 2 syntax. The line was changed to use the `format()` function instead.