### PR TITLE
init meta string container to None in case they are omitted during runtime (APS_1ID)

### DIFF
--- a/dxchange/reader.py
+++ b/dxchange/reader.py
@@ -308,6 +308,16 @@ def read_aps_1id_metafile(metafn):
         # skip over the incomplete layer
         if not layers_isValid[layerID]: continue
 
+        # init meta line as None
+        # NOTE:
+        #    These meta string might or might not present in the meta file,
+        #    depending on runtime settings
+        path = None
+        prefix = None
+        energy = None
+        image_type = None
+        tomo_metastr = None
+
         # prep for current layer
         layer_rawlines = rawlines[lns[0]:lns[1]]
         cycled_imgtypes = cycle(['pre_white', 


### PR DESCRIPTION
Some older metadata files do not have all the entries (meta strings) in the header, which can break the parsing.  Initialize the associated variables to None can help circumvent this issue.