### PR TITLE
BLD: add pandas dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ edffile
 tifffile    
 dxfile
 fnmatch
+pandas


### PR DESCRIPTION
In #71 the `pandas` import was introduced, but there is no corresponding update in the `requirements.txt`. This PR fixes it. Noticed during the work on https://github.com/NSLS-II/docs/pull/95 (tomopy-bluesky example).