### PR TITLE
BLD: Specify dxchange package directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name='dxchange',
     author='Doga Gursoy, Francesco De Carlo',
-    packages=find_packages(),
+    packages=['dxchange'],
     version=open('VERSION').read().strip(),
     description = 'Data I/O for tomography.',
     license='BSD-3',


### PR DESCRIPTION
find_packages from setuptools decides that test is a python
module that needs to also be installed. This patch directly lists
dxchange as the only module so that the tests are not also
installed in the end-users environment.