### PR TITLE
fix SyntaxWarning with Python3.13

### DIFF
--- a/dxchange/writer.py
+++ b/dxchange/writer.py
@@ -102,7 +102,7 @@ def get_extension(fname):
 
 
 def remove_trailing_digits(text):
-    digit_string = re.search('\d+$', text)
+    digit_string = re.search(r'\d+$', text)
     if digit_string is not None:
         number_of_digits = len(digit_string.group())
         text = ''.join(text[:-number_of_digits])


### PR DESCRIPTION
Hi,

Here's more:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1085558